### PR TITLE
Bug: multipart single-author affils weren't being parsed correctly

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -6,8 +6,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
     - uses: actions/checkout@v2
@@ -25,4 +23,7 @@ jobs:
       run: |
         python -m pytest
 
-    - run: coveralls
+    - name: Upload coverage data to coveralls.io
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ADSAffil/app.py
+++ b/ADSAffil/app.py
@@ -123,17 +123,15 @@ class ADSAffilCelery(ADSCelery):
                                 self.instring = v
                                 self._norm_affil()
                                 (aid, can, fac, idcode) = self._augmenter()
-                        abb_list.append(aid)
-                        id_list.append(idcode)
-                        can_list.append(can)
-                        if fac:
-                            facet_list.append(fac)
-                        else:
-                            if v != u'' and v != u'-':
-                                can_list = u'; '.join(can_list)
-                                abbreviation_list.append(u'; '.join(abb_list))
-                                id_code_list.append(u'; '.join(id_list))
-                                canonical_list.append(can_list)
+                            abb_list.append(aid)
+                            id_list.append(idcode)
+                            can_list.append(can)
+                            if fac:
+                                facet_list.append(fac)
+                        can_list = u'; '.join(can_list)
+                        abbreviation_list.append(u'; '.join(abb_list))
+                        id_code_list.append(u'; '.join(id_list))
+                        canonical_list.append(can_list)
                     else:
                         # call augmenter with string s and the dicts
                         self.instring = s

--- a/ADSAffil/tests/stubdata/record6.json
+++ b/ADSAffil/tests/stubdata/record6.json
@@ -1,0 +1,1 @@
+{"response": {"docs": [{"bibcode": "2021FOO...576..963T", "aff": [ "University of Unbridled Nonsense", "University of Irrational Exuberance", "Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; University of Unbridled Nonsense"]}]}}

--- a/ADSAffil/tests/stubdata/record7.json
+++ b/ADSAffil/tests/stubdata/record7.json
@@ -1,0 +1,1 @@
+{"response": {"docs": [{"bibcode": "2021FOO...576..963T", "aff": ["Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; Institute of the Early Universe, Ewha Womans University, Seoul, 120-750 Korea"]}]}}

--- a/ADSAffil/tests/test_app.py
+++ b/ADSAffil/tests/test_app.py
@@ -75,10 +75,27 @@ class TestApp(unittest.TestCase):
             jdata = json.load(fj)
         rec = jdata['response']['docs'][0]
         output_record = matcher.augment_affiliations(rec)
-        print(output_record)
         expected_record = {'bibcode': '2021ASDFQ.576..963T', 'aff': ['-'], 'aff_abbrev': ['-'], 'aff_id': ['-'], 'aff_canonical': ['-'], 'aff_facet_hier': [], 'aff_raw': ['-'], 'institution': ['-']}
         self.assertEqual(output_record, expected_record)
  
+        # seventh test: try augmenting a record with some unmatched affs AND a multipart aff (one known ; one unknown):
+        test_json = stubdata_dir + '/record6.json'
+        with open(test_json,'r') as fj:
+            jdata = json.load(fj)
+        rec = jdata['response']['docs'][0]
+        output_record = matcher.augment_affiliations(rec)
+        expected_record = {'bibcode': '2021FOO...576..963T', 'aff': ['University of Unbridled Nonsense', 'University of Irrational Exuberance', 'Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; University of Unbridled Nonsense'], 'aff_abbrev': ['-', '-', 'Yale U/Dep Ast; -'], 'aff_id': ['-', '-', 'A00928; -'], 'aff_canonical': ['-', '-', 'Yale University, Department of Astronomy; -'], 'aff_facet_hier': ['0/Yale U', '1/Yale U/Dep Ast'], 'aff_raw': ['University of Unbridled Nonsense', 'University of Irrational Exuberance', 'Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; University of Unbridled Nonsense'], 'institution': ['-', '-', 'Yale U/Dep Ast; -']}
+        self.assertEqual(output_record, expected_record)
+
+        # eighth test: try augmenting a record a multipart affil where both are known strings:
+        test_json = stubdata_dir + '/record7.json'
+        with open(test_json,'r') as fj:
+            jdata = json.load(fj)
+        rec = jdata['response']['docs'][0]
+        output_record = matcher.augment_affiliations(rec)
+        expected_record = {'bibcode': '2021FOO...576..963T', 'aff': ['Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; Institute of the Early Universe, Ewha Womans University, Seoul, 120-750 Korea'], 'aff_abbrev': ['Yale U/Dep Ast; Ewha Wmns U/Inst Early Uni'], 'aff_id': ['A00928; A11557'], 'aff_canonical': ['Yale University, Department of Astronomy; Ewha Womans University, Institute for the Early Universe'], 'aff_facet_hier': ['0/Yale U', '1/Yale U/Dep Ast', '0/Ewha Wmns U', '1/Ewha Wmns U/Inst Early Uni'], 'aff_raw': ['Astronomy Department, Yale University, P.O. Box 208101, New Haven, CT 06520-8101; Institute of the Early Universe, Ewha Womans University, Seoul, 120-750 Korea'], 'institution': ['Yale U/Dep Ast; Ewha Wmns U/Inst Early Uni']}
+        self.assertEqual(output_record, expected_record)
+
 
     def test_return_exact_matches(self):
         aff_pickle_filename = stubdata_dir + '/aff.pickle'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 coverage==5.3
-coveralls==2.1.2
+coveralls==2.2.0
 mock==4.0.2
 pytest==6.0.2
 pytest-cov==2.10.1


### PR DESCRIPTION
Affiliations for a single author of the form "Institution A; Institution B; Institution C" were not being properly augmented; only the last affiliation (Institution C) was being reported in the augmented record.

This fix correctly splits these affiliations at the semicolon, matches each individually, and then appends *all* of them to the resulting list, not just the last record.

Two additional test cases were added to tests/test_app.py to check this.